### PR TITLE
Fix start/finish contract

### DIFF
--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -67,9 +67,9 @@ contract Marketplace is Collateral {
     require(request.client == msg.sender, "Only client can select offer");
 
     RequestState storage state = requestState[offer.requestId];
-    require(!state.offerSelected, "Offer already selected");
+    require(state.selectedOffer == bytes32(0), "Offer already selected");
 
-    state.offerSelected = true;
+    state.selectedOffer = id;
 
     _createLock(id, offer.expiry);
     _lock(offer.host, id);
@@ -91,6 +91,10 @@ contract Marketplace is Collateral {
     return offers[id];
   }
 
+  function _selectedOffer(bytes32 requestId) internal view returns (bytes32) {
+    return requestState[requestId].selectedOffer;
+  }
+
   struct Request {
     address client;
     uint256 duration;
@@ -103,7 +107,7 @@ contract Marketplace is Collateral {
   }
 
   struct RequestState {
-    bool offerSelected;
+    bytes32 selectedOffer;
   }
 
   struct Offer {

--- a/contracts/Storage.sol
+++ b/contracts/Storage.sol
@@ -32,6 +32,7 @@ contract Storage is Collateral, Marketplace, Proofs {
   function startContract(bytes32 id) public {
     Offer storage offer = _offer(id);
     require(msg.sender == offer.host, "Only host can call this function");
+    require(_selectedOffer(offer.requestId) == id, "Offer was not selected");
     Request storage request = _request(offer.requestId);
     _expectProofs(id, request.proofProbability, request.duration);
   }

--- a/test/Storage.test.js
+++ b/test/Storage.test.js
@@ -70,6 +70,15 @@ describe("Storage", function () {
       await storage.startContract(id)
       await expect(storage.startContract(id)).to.be.reverted
     })
+
+    it("can only be done for a selected offer", async function () {
+      switchAccount(host)
+      const differentOffer = { ...offer, price: offer.price * 2 }
+      await storage.offerStorage(differentOffer)
+      await expect(
+        storage.startContract(offerId(differentOffer))
+      ).to.be.revertedWith("Offer was not selected")
+    })
   })
 
   describe("finishing the contract", function () {


### PR DESCRIPTION
- check that starting a contract is only allowed when the corresponding offer has been selected by the client
- check that finishing a contract is only allowed if it's been started in the first place