### PR TITLE
Check whether proof will be required soon

### DIFF
--- a/contracts/Storage.sol
+++ b/contracts/Storage.sol
@@ -66,6 +66,10 @@ contract Storage is Collateral, Marketplace, Proofs {
     return _isProofRequired(contractId);
   }
 
+  function willProofBeRequired(bytes32 contractId) public view returns (bool) {
+    return _willProofBeRequired(contractId);
+  }
+
   function getChallenge(bytes32 contractId) public view returns (bytes32) {
     return _getChallenge(contractId);
   }

--- a/contracts/TestProofs.sol
+++ b/contracts/TestProofs.sol
@@ -44,6 +44,10 @@ contract TestProofs is Proofs {
     return _isProofRequired(id);
   }
 
+  function willProofBeRequired(bytes32 id) public view returns (bool) {
+    return _willProofBeRequired(id);
+  }
+
   function getChallenge(bytes32 id) public view returns (bytes32) {
     return _getChallenge(id);
   }

--- a/test/evm.js
+++ b/test/evm.js
@@ -14,9 +14,13 @@ async function revert() {
   await ethers.provider.send("evm_setNextBlockTimestamp", [time + 1])
 }
 
+async function mine() {
+  await ethers.provider.send("evm_mine")
+}
+
 async function ensureMinimumBlockHeight(height) {
   while ((await ethers.provider.getBlockNumber()) < height) {
-    await ethers.provider.send("evm_mine")
+    await mine()
   }
 }
 
@@ -27,19 +31,20 @@ async function currentTime() {
 
 async function advanceTime(seconds) {
   await ethers.provider.send("evm_increaseTime", [seconds])
-  await ethers.provider.send("evm_mine")
+  await mine()
 }
 
 async function advanceTimeTo(timestamp) {
   if ((await currentTime()) !== timestamp) {
     await ethers.provider.send("evm_setNextBlockTimestamp", [timestamp])
-    await ethers.provider.send("evm_mine")
+    await mine()
   }
 }
 
 module.exports = {
   snapshot,
   revert,
+  mine,
   ensureMinimumBlockHeight,
   currentTime,
   advanceTime,


### PR DESCRIPTION
Adds a function `willProofBeRequired()` which checks whether a proof will soon be required. When [pointer is in downtime][1], but still points to a blockhash that requires a proof to be submitted, then this function will return true. Together with the pointer position, this allows a host to determine whether or not it makes sense to produce a proof for the current period.

[1]: https://github.com/status-im/dagger-research/blob/main/design/storage-proof-timing.md#pointer-downtime

