### PR TITLE
Submit proof event

### DIFF
--- a/contracts/Proofs.sol
+++ b/contracts/Proofs.sol
@@ -136,10 +136,11 @@ contract Proofs {
     return isRequired && pointer < downtime;
   }
 
-  function _submitProof(bytes32 id, bool proof) internal {
-    require(proof, "Invalid proof"); // TODO: replace bool by actual proof
+  function _submitProof(bytes32 id, bytes calldata proof) internal {
+    require(proof.length > 0, "Invalid proof"); // TODO: replace by actual check
     require(!received[id][currentPeriod()], "Proof already submitted");
     received[id][currentPeriod()] = true;
+    emit ProofSubmitted(id, proof);
   }
 
   function _markProofAsMissing(bytes32 id, uint256 missedPeriod) internal {
@@ -152,4 +153,6 @@ contract Proofs {
     missing[id][missedPeriod] = true;
     missed[id] += 1;
   }
+
+  event ProofSubmitted(bytes32 id, bytes proof);
 }

--- a/contracts/Storage.sol
+++ b/contracts/Storage.sol
@@ -86,7 +86,7 @@ contract Storage is Collateral, Marketplace, Proofs {
     return _getPointer(id);
   }
 
-  function submitProof(bytes32 contractId, bool proof) public {
+  function submitProof(bytes32 contractId, bytes calldata proof) public {
     _submitProof(contractId, proof);
   }
 

--- a/contracts/TestProofs.sol
+++ b/contracts/TestProofs.sol
@@ -56,7 +56,7 @@ contract TestProofs is Proofs {
     return _getPointer(id);
   }
 
-  function submitProof(bytes32 id, bool proof) public {
+  function submitProof(bytes32 id, bytes calldata proof) public {
     _submitProof(id, proof);
   }
 

--- a/test/Marketplace.test.js
+++ b/test/Marketplace.test.js
@@ -148,7 +148,7 @@ describe("Marketplace", function () {
     })
   })
 
-  describe("selecting an offer", async function () {
+  describe("selecting an offer", function () {
     beforeEach(async function () {
       switchAccount(client)
       await token.approve(marketplace.address, request.ask.maxPrice)

--- a/test/Proofs.test.js
+++ b/test/Proofs.test.js
@@ -139,7 +139,7 @@ describe("Proofs", function () {
     })
   })
 
-  describe("when proofs are required", async function () {
+  describe("when proofs are required", function () {
     beforeEach(async function () {
       await proofs.expectProofs(id, probability, duration)
     })


### PR DESCRIPTION
Emit an event containing the proof when it's submitted.
This allows a validator to listen for submitted proofs.