### PR TITLE
Start contract on proof submission

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -36,42 +36,34 @@ When all goes well, the client and host perform the following steps:
       |                                            |
       | --------------- request (1) -------------> |
       |                                            |
-      |                     | ---- offer (2) ----> |
-      |                                            |
-      | ------------- select offer (3) ----------> |
-      |                                            |
-      | ----- data (4) ---> |                      |
+      | ----- data (2) ---> |                      |
+      |                     |                      |
+                            | --- fulfill (3) ---> |
                             |                      |
-                            | ---- start (5) ----> |
+                            | ---- proof (4) ----> |
                             |                      |
-                            | ---- proof (6) ----> |
+                            | ---- proof (4) ----> |
                             |                      |
-                            | ---- proof (6) ----> |
+                            | ---- proof (4) ----> |
                             |                      |
-                            | ---- proof (6) ----> |
-                            |                      |
-                            | <-- payment (7) ---- |
+                            | <-- payment (5) ---- |
 
   1. Client submits a request for storage, containing the size of the data that
      it wants to store and the length of time it wants to store it
-  2. Several hosts submit offers containing a price
-  3. The client selects an offer
-  4. The client sends the data it wants to store to the host
-  5. Once the host has received the data it starts the storage contract
-  6. While the storage contract is active, the host proves that it is still
+  2. Client makes the data available to hosts
+  3. The first host to submit a storage proof can fulfill the request
+  4. While the storage contract is active, the host proves that it is still
      storing the data by responding to frequent random challenges
-  7. At the end of the contract the host is paid
+  5. At the end of the contract the host is paid
 
 Contracts
 ---------
 
-A storage contract can be negotiated through requests and offers. A request
-contains the size of the data and the length of time during which it needs to be
-stored. It also contains a maximum price that a client is willing to pay and
-proof requirements such as how often a proof will need to be submitted by the
-host. A random nonce is included to ensure uniqueness among similar requests. An
-offer contains a reference to the request it pertains to, a price, and an expiry
-time.
+A storage contract can be negotiated through requests. A request contains the
+size of the data and the length of time during which it needs to be stored. It
+also contains a reward that a client is willing to pay and proof requirements
+such as how often a proof will need to be submitted by the host. A random nonce
+is included to ensure uniqueness among similar requests.
 
 When a new storage contract is created the client immediately pays the entire
 price of the contract. The payment is only released to the host upon successful
@@ -119,14 +111,6 @@ To Do
 
     Allow another host to take over a contract when the original host missed too
     many proofs.
-
-  * Start failures
-
-    When a contract fails to start it should be aborted after a timeout. A
-    contract may fail to start because the client failed to send the data, or
-    because the host failed to start the contract. To discourage this, a small
-    portion of both the client and host money can be burned if the contract
-    doesn't start within a certain amount of time.
 
   * Reward validators
 

--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -60,6 +60,11 @@ contract Marketplace is Collateral, Proofs {
     require(balanceOf(msg.sender) >= collateral, "Insufficient collateral");
     _lock(msg.sender, requestId);
 
+    _expectProofs(
+      requestId,
+      request.ask.proofProbability,
+      request.ask.duration
+    );
     _submitProof(requestId, proof);
 
     state.fulfilled = true;
@@ -121,6 +126,18 @@ contract Marketplace is Collateral, Proofs {
 
   function _selectedOffer(bytes32 requestId) internal view returns (bytes32) {
     return requestState[requestId].selectedOffer;
+  }
+
+  function proofPeriod() public view returns (uint256) {
+    return _period();
+  }
+
+  function proofTimeout() public view returns (uint256) {
+    return _timeout();
+  }
+
+  function proofEnd(bytes32 contractId) public view returns (uint256) {
+    return _end(contractId);
   }
 
   struct Request {

--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -38,9 +38,9 @@ contract Marketplace is Collateral, Proofs {
 
     _createLock(id, request.expiry);
 
-    funds.received += request.ask.maxPrice;
-    funds.balance += request.ask.maxPrice;
-    transferFrom(msg.sender, request.ask.maxPrice);
+    funds.received += request.ask.reward;
+    funds.balance += request.ask.reward;
+    transferFrom(msg.sender, request.ask.reward);
 
     emit StorageRequested(id, request.ask);
   }
@@ -102,7 +102,7 @@ contract Marketplace is Collateral, Proofs {
     uint256 size; // size of requested storage in number of bytes
     uint256 duration; // how long content should be stored (in seconds)
     uint256 proofProbability; // how often storage proofs are required
-    uint256 maxPrice; // maximum price client will pay (in number of tokens)
+    uint256 reward; // reward that the client will pay (in number of tokens)
   }
 
   struct Content {

--- a/contracts/Storage.sol
+++ b/contracts/Storage.sol
@@ -5,7 +5,7 @@ import "./Marketplace.sol";
 import "./Proofs.sol";
 import "./Collateral.sol";
 
-contract Storage is Collateral, Marketplace, Proofs {
+contract Storage is Collateral, Marketplace {
   uint256 public collateralAmount;
   uint256 public slashMisses;
   uint256 public slashPercentage;
@@ -21,8 +21,13 @@ contract Storage is Collateral, Marketplace, Proofs {
     uint256 _slashMisses,
     uint256 _slashPercentage
   )
-    Marketplace(token, _collateralAmount)
-    Proofs(_proofPeriod, _proofTimeout, _proofDowntime)
+    Marketplace(
+      token,
+      _collateralAmount,
+      _proofPeriod,
+      _proofTimeout,
+      _proofDowntime
+    )
   {
     collateralAmount = _collateralAmount;
     slashMisses = _slashMisses;

--- a/contracts/Storage.sol
+++ b/contracts/Storage.sol
@@ -38,6 +38,10 @@ contract Storage is Collateral, Marketplace {
     return _request(id);
   }
 
+  function getHost(bytes32 id) public view returns (address) {
+    return _host(id);
+  }
+
   function finishContract(bytes32 id) public {
     require(_host(id) != address(0), "Contract not started");
     require(!contractFinished[id], "Contract already finished");

--- a/contracts/Storage.sol
+++ b/contracts/Storage.sol
@@ -44,7 +44,7 @@ contract Storage is Collateral, Marketplace {
     require(block.timestamp > proofEnd(id), "Contract has not ended yet");
     contractFinished[id] = true;
     require(
-      token.transfer(_host(id), _request(id).ask.maxPrice),
+      token.transfer(_host(id), _request(id).ask.reward),
       "Payment failed"
     );
   }

--- a/contracts/Storage.sol
+++ b/contracts/Storage.sol
@@ -59,18 +59,6 @@ contract Storage is Collateral, Marketplace {
     require(token.transfer(offer.host, offer.price), "Payment failed");
   }
 
-  function proofPeriod() public view returns (uint256) {
-    return _period();
-  }
-
-  function proofTimeout() public view returns (uint256) {
-    return _timeout();
-  }
-
-  function proofEnd(bytes32 contractId) public view returns (uint256) {
-    return _end(contractId);
-  }
-
   function missingProofs(bytes32 contractId) public view returns (uint256) {
     return _missed(contractId);
   }

--- a/test/Marketplace.test.js
+++ b/test/Marketplace.test.js
@@ -115,6 +115,11 @@ describe("Marketplace", function () {
       await expect(marketplace.withdraw()).to.be.revertedWith("Account locked")
     })
 
+    it("starts requiring storage proofs", async function () {
+      await marketplace.fulfillRequest(requestId(request), proof)
+      expect(await marketplace.proofEnd(requestId(request))).to.be.gt(0)
+    })
+
     it("is rejected when proof is incorrect", async function () {
       let invalid = hexlify([])
       await expect(

--- a/test/Marketplace.test.js
+++ b/test/Marketplace.test.js
@@ -57,7 +57,7 @@ describe("Marketplace", function () {
     })
 
     it("emits event when storage is requested", async function () {
-      await token.approve(marketplace.address, request.ask.maxPrice)
+      await token.approve(marketplace.address, request.ask.reward)
       await expect(marketplace.requestStorage(request))
         .to.emit(marketplace, "StorageRequested")
         .withArgs(requestId(request), askToArray(request.ask))
@@ -65,14 +65,14 @@ describe("Marketplace", function () {
 
     it("rejects request with invalid client address", async function () {
       let invalid = { ...request, client: host.address }
-      await token.approve(marketplace.address, invalid.ask.maxPrice)
+      await token.approve(marketplace.address, invalid.ask.reward)
       await expect(marketplace.requestStorage(invalid)).to.be.revertedWith(
         "Invalid client address"
       )
     })
 
     it("rejects request with insufficient payment", async function () {
-      let insufficient = request.ask.maxPrice - 1
+      let insufficient = request.ask.reward - 1
       await token.approve(marketplace.address, insufficient)
       await expect(marketplace.requestStorage(request)).to.be.revertedWith(
         "ERC20: insufficient allowance"
@@ -80,7 +80,7 @@ describe("Marketplace", function () {
     })
 
     it("rejects resubmission of request", async function () {
-      await token.approve(marketplace.address, request.ask.maxPrice * 2)
+      await token.approve(marketplace.address, request.ask.reward * 2)
       await marketplace.requestStorage(request)
       await expect(marketplace.requestStorage(request)).to.be.revertedWith(
         "Request already exists"
@@ -93,7 +93,7 @@ describe("Marketplace", function () {
 
     beforeEach(async function () {
       switchAccount(client)
-      await token.approve(marketplace.address, request.ask.maxPrice)
+      await token.approve(marketplace.address, request.ask.reward)
       await marketplace.requestStorage(request)
       switchAccount(host)
       await token.approve(marketplace.address, collateral)
@@ -150,7 +150,7 @@ describe("Marketplace", function () {
     it("is rejected when request is expired", async function () {
       switchAccount(client)
       let expired = { ...request, expiry: now() - hours(1) }
-      await token.approve(marketplace.address, request.ask.maxPrice)
+      await token.approve(marketplace.address, request.ask.reward)
       await marketplace.requestStorage(expired)
       switchAccount(host)
       await expect(

--- a/test/Storage.test.js
+++ b/test/Storage.test.js
@@ -1,6 +1,7 @@
 const { expect } = require("chai")
 const { ethers, deployments } = require("hardhat")
 const { hexlify, randomBytes } = ethers.utils
+const { AddressZero } = ethers.constants
 const { exampleRequest } = require("./examples")
 const { advanceTime, advanceTimeTo, currentTime } = require("./evm")
 const { requestId } = require("./ids")
@@ -53,6 +54,12 @@ describe("Storage", function () {
     expect(retrieved.client).to.equal(request.client)
     expect(retrieved.expiry).to.equal(request.expiry)
     expect(retrieved.nonce).to.equal(request.nonce)
+  })
+
+  it("can retrieve host that fulfilled request", async function () {
+    expect(await storage.getHost(requestId(request))).to.equal(AddressZero)
+    await storage.fulfillRequest(requestId(request), proof)
+    expect(await storage.getHost(requestId(request))).to.equal(host.address)
   })
 
   describe("finishing the contract", function () {

--- a/test/Storage.test.js
+++ b/test/Storage.test.js
@@ -40,7 +40,7 @@ describe("Storage", function () {
     id = requestId(request)
 
     switchAccount(client)
-    await token.approve(storage.address, request.ask.maxPrice)
+    await token.approve(storage.address, request.ask.reward)
     await storage.requestStorage(request)
     switchAccount(host)
     await token.approve(storage.address, collateralAmount)
@@ -74,7 +74,7 @@ describe("Storage", function () {
       const startBalance = await token.balanceOf(host.address)
       await storage.finishContract(id)
       const endBalance = await token.balanceOf(host.address)
-      expect(endBalance - startBalance).to.equal(request.ask.maxPrice)
+      expect(endBalance - startBalance).to.equal(request.ask.reward)
     })
 
     it("is only allowed when the contract has started", async function () {

--- a/test/examples.js
+++ b/test/examples.js
@@ -8,7 +8,7 @@ const exampleRequest = () => ({
     size: 1 * 1024 * 1024 * 1024, // 1 Gigabyte
     duration: hours(10),
     proofProbability: 4, // require a proof roughly once every 4 periods
-    maxPrice: 84,
+    reward: 84,
   },
   content: {
     cid: "zb2rhheVmk3bLks5MgzTqyznLu1zqGH5jrfTA1eAZXrjx7Vob",

--- a/test/examples.js
+++ b/test/examples.js
@@ -27,21 +27,9 @@ const exampleRequest = () => ({
   nonce: hexlify(randomBytes(32)),
 })
 
-const exampleBid = () => ({
-  price: 42,
-  bidExpiry: now() + hours(1),
-})
-
-const exampleOffer = () => ({
-  requestId: hexlify(randomBytes(32)),
-  host: hexlify(randomBytes(20)),
-  price: 42,
-  expiry: now() + hours(1),
-})
-
 const exampleLock = () => ({
   id: hexlify(randomBytes(32)),
   expiry: now() + hours(1),
 })
 
-module.exports = { exampleRequest, exampleOffer, exampleBid, exampleLock }
+module.exports = { exampleRequest, exampleLock }

--- a/test/ids.js
+++ b/test/ids.js
@@ -12,7 +12,7 @@ function requestId(request) {
 }
 
 function askToArray(ask) {
-  return [ask.size, ask.duration, ask.proofProbability, ask.maxPrice]
+  return [ask.size, ask.duration, ask.proofProbability, ask.reward]
 }
 
 function erasureToArray(erasure) {

--- a/test/ids.js
+++ b/test/ids.js
@@ -11,15 +11,6 @@ function requestId(request) {
   return keccak256(defaultAbiCoder.encode([Request], requestToArray(request)))
 }
 
-function offerId(offer) {
-  return keccak256(
-    defaultAbiCoder.encode(
-      ["address", "bytes32", "uint256", "uint256"],
-      offerToArray(offer)
-    )
-  )
-}
-
 function askToArray(ask) {
   return [ask.size, ask.duration, ask.proofProbability, ask.maxPrice]
 }
@@ -48,14 +39,8 @@ function requestToArray(request) {
   ]
 }
 
-function offerToArray(offer) {
-  return [offer.host, offer.requestId, offer.price, offer.expiry]
-}
-
 module.exports = {
   requestId,
-  offerId,
   requestToArray,
   askToArray,
-  offerToArray,
 }


### PR DESCRIPTION
Remove the negotiation steps whereby a host submits an offer and a client selects an offer. Start the contract with the host that submits the first proof of storage.

A first step towards the design in https://github.com/status-im/codex-research/pull/83.