### PR TITLE
[marketplace] Add request state and add/remove slot proving based on state

### DIFF
--- a/contracts/AccountLocks.sol
+++ b/contracts/AccountLocks.sol
@@ -42,6 +42,18 @@ contract AccountLocks {
     lock.unlocked = true;
   }
 
+  /// Extends the locks expiry time. Lock must not have already expired.
+  /// NOTE: We do not need to check that msg.sender is the lock.owner because
+  /// this function is internal, and is only called after all checks have been
+  /// performed in Marketplace.fillSlot.
+  function _extendLockExpiry(bytes32 lockId, uint256 duration) internal {
+    Lock storage lock = locks[lockId];
+    require(lock.owner != address(0), "Lock does not exist");
+    // require(lock.owner == msg.sender, "Only lock creator can extend expiry");
+    require(lock.expiry >= block.timestamp, "Lock already expired");
+    lock.expiry += duration;
+  }
+
   /// Unlocks an account. This will fail if there are any active locks attached
   /// to this account.
   /// Calling this function triggers a cleanup of inactive locks, making this

--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -76,6 +76,7 @@ contract Marketplace is Collateral, Proofs {
     emit SlotFilled(requestId, slotIndex, slotId);
     if (context.slotsFilled == request.ask.slots) {
       context.state = RequestState.Started;
+      _extendLockExpiry(requestId, block.timestamp + request.ask.duration);
       emit RequestFulfilled(requestId);
     }
   }

--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -116,6 +116,16 @@ contract Marketplace is Collateral, Proofs {
     emit RequestCancelled(requestId);
   }
 
+  function isCancelled(bytes32 requestId) public view returns (bool) {
+    RequestContext storage context = requestContexts[requestId];
+    return
+      context.state == RequestState.Cancelled ||
+      (
+        context.state == RequestState.New &&
+        block.timestamp > requests[requestId].expiry
+      );
+  }
+
   function _host(bytes32 slotId) internal view returns (address) {
     return slots[slotId].host;
   }

--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -182,10 +182,11 @@ contract Marketplace is Collateral, Proofs {
   }
 
   function proofEnd(bytes32 slotId) public view returns (uint256) {
+    uint256 end = _end(slotId);
     if (!_slotAcceptsProofs(slotId)) {
-      return block.timestamp - 1;
+      return end < block.timestamp ? end : block.timestamp - 1;
     }
-    return _end(slotId);
+    return end;
   }
 
   function _price(

--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -97,6 +97,9 @@ contract Marketplace is Collateral, Proofs {
     require(token.transfer(slot.host, amount), "Payment failed");
   }
 
+  /// @notice Withdraws storage request funds back to the client that deposited them.
+  /// @dev Request must be expired, must be in RequestState.New, and the transaction must originate from the depositer address.
+  /// @param requestId the id of the request
   function withdrawFunds(bytes32 requestId) public marketplaceInvariant {
     Request memory request = requests[requestId];
     require(block.timestamp > request.expiry, "Request not yet timed out");
@@ -116,6 +119,10 @@ contract Marketplace is Collateral, Proofs {
     emit RequestCancelled(requestId);
   }
 
+  /// @notice Rseturn true if the request state is RequestState.Cancelled or if the request expiry time has elapsed and the request was never started.
+  /// @dev Handles the case when a request may have been cancelled, but the client has not withdrawn its funds yet, and therefore the state has not yet been updated.
+  /// @param requestId the id of the request
+  /// @return true if request is cancelled
   function isCancelled(bytes32 requestId) public view returns (bool) {
     RequestContext storage context = requestContexts[requestId];
     return

--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -263,7 +263,7 @@ contract Marketplace is Collateral, Proofs {
     uint256 indexed slotIndex,
     bytes32 indexed slotId
   );
-  event RequestCancelled(bytes32 requestId);
+  event RequestCancelled(bytes32 indexed requestId);
 
   modifier marketplaceInvariant() {
     MarketplaceFunds memory oldFunds = funds;

--- a/contracts/Storage.sol
+++ b/contracts/Storage.sol
@@ -65,6 +65,7 @@ contract Storage is Collateral, Marketplace {
   }
 
   function markProofAsMissing(bytes32 slotId, uint256 period) public {
+    require(!isCancelled(slotId), "Request was cancelled");
     _markProofAsMissing(slotId, period);
     if (_missed(slotId) % slashMisses == 0) {
       _slash(_host(slotId), slashPercentage);

--- a/contracts/Storage.sol
+++ b/contracts/Storage.sol
@@ -40,14 +40,6 @@ contract Storage is Collateral, Marketplace {
     return _slot(slotId);
   }
 
-  function isCancelled(bytes32 requestId) public view returns(bool) {
-    return _isCancelled(requestId);
-  }
-
-  function isSlotCancelled(bytes32 slotId) public view returns (bool) {
-    return _isSlotCancelled(slotId);
-  }
-
   function getHost(bytes32 requestId) public view returns (address) {
     return _host(requestId);
   }
@@ -57,14 +49,23 @@ contract Storage is Collateral, Marketplace {
   }
 
   function isProofRequired(bytes32 slotId) public view returns (bool) {
+    if(!_slotAcceptsProofs(slotId)) {
+      return false;
+    }
     return _isProofRequired(slotId);
   }
 
   function willProofBeRequired(bytes32 slotId) public view returns (bool) {
+    if(!_slotAcceptsProofs(slotId)) {
+      return false;
+    }
     return _willProofBeRequired(slotId);
   }
 
   function getChallenge(bytes32 slotId) public view returns (bytes32) {
+    if(!_slotAcceptsProofs(slotId)) {
+      return bytes32(0);
+    }
     return _getChallenge(slotId);
   }
 
@@ -76,8 +77,10 @@ contract Storage is Collateral, Marketplace {
     _submitProof(slotId, proof);
   }
 
-  function markProofAsMissing(bytes32 slotId, uint256 period) public {
-    require(!isSlotCancelled(slotId), "Request was cancelled");
+  function markProofAsMissing(bytes32 slotId, uint256 period)
+    public
+    slotMustAcceptProofs(slotId)
+  {
     _markProofAsMissing(slotId, period);
     if (_missed(slotId) % slashMisses == 0) {
       _slash(_host(slotId), slashPercentage);

--- a/contracts/Storage.sol
+++ b/contracts/Storage.sol
@@ -36,6 +36,18 @@ contract Storage is Collateral, Marketplace {
     return _request(requestId);
   }
 
+  function getSlot(bytes32 slotId) public view returns (Slot memory) {
+    return _slot(slotId);
+  }
+
+  function isCancelled(bytes32 requestId) public view returns(bool) {
+    return _isCancelled(requestId);
+  }
+
+  function isSlotCancelled(bytes32 slotId) public view returns (bool) {
+    return _isSlotCancelled(slotId);
+  }
+
   function getHost(bytes32 requestId) public view returns (address) {
     return _host(requestId);
   }

--- a/contracts/Storage.sol
+++ b/contracts/Storage.sol
@@ -65,7 +65,7 @@ contract Storage is Collateral, Marketplace {
   }
 
   function markProofAsMissing(bytes32 slotId, uint256 period) public {
-    require(!isCancelled(slotId), "Request was cancelled");
+    require(!isSlotCancelled(slotId), "Request was cancelled");
     _markProofAsMissing(slotId, period);
     if (_missed(slotId) % slashMisses == 0) {
       _slash(_host(slotId), slashPercentage);

--- a/contracts/TestAccountLocks.sol
+++ b/contracts/TestAccountLocks.sol
@@ -20,4 +20,8 @@ contract TestAccountLocks is AccountLocks {
   function unlockAccount() public {
     _unlockAccount();
   }
+
+  function extendLockExpiry(bytes32 lockId, uint256 expiry) public {
+    _extendLockExpiry(lockId, expiry);
+  }
 }

--- a/contracts/TestMarketplace.sol
+++ b/contracts/TestMarketplace.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "./Marketplace.sol";
+
+// exposes internal functions of Marketplace for testing
+contract TestMarketplace is Marketplace {
+  constructor(
+    IERC20 _token,
+    uint256 _collateral,
+    uint256 _proofPeriod,
+    uint256 _proofTimeout,
+    uint8 _proofDowntime
+  )
+    Marketplace(_token, _collateral, _proofPeriod,_proofTimeout,_proofDowntime)
+  // solhint-disable-next-line no-empty-blocks
+  {
+
+  }
+
+  function isCancelled(bytes32 requestId) public view returns (bool) {
+    return _isCancelled(requestId);
+  }
+
+  function isSlotCancelled(bytes32 slotId) public view returns (bool) {
+    return _isSlotCancelled(slotId);
+  }
+}

--- a/test/AccountLocks.test.js
+++ b/test/AccountLocks.test.js
@@ -193,7 +193,7 @@ describe("Account Locks", function () {
     })
 
     it("fails when lock is already expired", async function () {
-      waitUntilExpired(expiry + hours(1))
+      waitUntilExpired(expiry)
       await expect(locks.extendLockExpiry(id, hours(1))).to.be.revertedWith(
         "Lock already expired"
       )

--- a/test/Marketplace.test.js
+++ b/test/Marketplace.test.js
@@ -351,26 +351,6 @@ describe("Marketplace", function () {
       Failed: 4,
     }
 
-    it("isCancelled is true once request is cancelled", async function () {
-      await expect(await marketplace.isCancelled(slot.request)).to.equal(false)
-      await waitUntilExpired(request.expiry)
-      await expect(await marketplace.isCancelled(slot.request)).to.equal(true)
-    })
-
-    it("isSlotCancelled fails when slot is empty", async function () {
-      await expect(
-        marketplace.isSlotCancelled(slotId(slot))
-      ).to.be.revertedWith("Slot empty")
-    })
-
-    it("isSlotCancelled is true once request is cancelled", async function () {
-      await marketplace.fillSlot(slot.request, slot.index, proof)
-      await waitUntilExpired(request.expiry)
-      await expect(await marketplace.isSlotCancelled(slotId(slot))).to.equal(
-        true
-      )
-    })
-
     it("state is Cancelled when client withdraws funds", async function () {
       await expect(await marketplace.state(slot.request)).to.equal(
         RequestState.New

--- a/test/Marketplace.test.js
+++ b/test/Marketplace.test.js
@@ -357,6 +357,20 @@ describe("Marketplace", function () {
       await expect(await marketplace.isCancelled(slot.request)).to.equal(true)
     })
 
+    it("isSlotCancelled fails when slot is empty", async function () {
+      await expect(
+        marketplace.isSlotCancelled(slotId(slot))
+      ).to.be.revertedWith("Slot empty")
+    })
+
+    it("isSlotCancelled is true once request is cancelled", async function () {
+      await marketplace.fillSlot(slot.request, slot.index, proof)
+      await waitUntilExpired(request.expiry)
+      await expect(await marketplace.isSlotCancelled(slotId(slot))).to.equal(
+        true
+      )
+    })
+
     it("state is Cancelled when client withdraws funds", async function () {
       await expect(await marketplace.state(slot.request)).to.equal(
         RequestState.New

--- a/test/Marketplace.test.js
+++ b/test/Marketplace.test.js
@@ -251,5 +251,12 @@ describe("Marketplace", function () {
         .to.emit(marketplace, "RequestFulfilled")
         .withArgs(requestId(request))
     })
+    it("sets state when all slots are filled", async function () {
+      const lastSlot = request.ask.slots - 1
+      for (let i = 0; i <= lastSlot; i++) {
+        await marketplace.fillSlot(slot.request, i, proof)
+      }
+      await expect(await marketplace.state(slot.request)).to.equal(1)
+    })
   })
 })

--- a/test/Storage.test.js
+++ b/test/Storage.test.js
@@ -111,6 +111,15 @@ describe("Storage", function () {
       const expectedBalance = (collateralAmount * (100 - slashPercentage)) / 100
       expect(await storage.balanceOf(host.address)).to.equal(expectedBalance)
     })
+
+    it("fails to mark proof as missing when cancelled", async function () {
+      await storage.fillSlot(slot.request, slot.index, proof)
+      await advanceTimeTo(request.expiry + 1)
+      let missedPeriod = periodOf(await currentTime())
+      await expect(
+        storage.markProofAsMissing(slotId(slot), missedPeriod)
+      ).to.be.revertedWith("Request was cancelled")
+    })
   })
 })
 

--- a/test/marketplace.js
+++ b/test/marketplace.js
@@ -1,0 +1,5 @@
+async function waitUntilExpired(expiry) {
+  await ethers.provider.send("hardhat_mine", [ethers.utils.hexValue(expiry)])
+}
+
+module.exports = { waitUntilExpired }

--- a/test/marketplace.js
+++ b/test/marketplace.js
@@ -1,5 +1,13 @@
+const RequestState = {
+  New: 0,
+  Started: 1,
+  Cancelled: 2,
+  Finished: 3,
+  Failed: 4,
+}
+
 async function waitUntilExpired(expiry) {
   await ethers.provider.send("hardhat_mine", [ethers.utils.hexValue(expiry)])
 }
 
-module.exports = { waitUntilExpired }
+module.exports = { waitUntilExpired, RequestState }


### PR DESCRIPTION
Once a storage request is created by the client, if all the slots are filled before the expiry lapses, the request state of the contract is set to `RequestState.Started`. The lock expiry (that prevents client funds withdrawal) is also extended.

If the expiry lapses before all slots are filled, the request state is considered cancelled, however the state cannot be automatically updated. At this point, the functions `isCancelled` and `isSlotCancelled` will return true. Also at this point, the client can withdraw its funds from the contract, and in that transaction, the request state of the contract is set to `RequestState.Cancelled`.

Proofs cannot be marked as missing when `isSlotCancelled` is true. This is the point at which a storage request's expiry lapsed before all slots were filled.

### NOTES
1. ~~This PR is based off of https://github.com/status-im/dagger-contracts/pull/15, which should probably be merged first and then this PR can be rebased on top of main afterwards.~~