### PR TITLE
[marketplace] alias bytes32 types

### DIFF
--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -75,7 +75,7 @@ contract Marketplace is Collateral, Proofs {
     ProofId proofId = _toProofId(slotId);
     _expectProofs(
       proofId,
-      requestId,
+      _toEndId(requestId),
       request.ask.proofProbability);
     _submitProof(proofId, proof);
 
@@ -117,7 +117,7 @@ contract Marketplace is Collateral, Proofs {
         context.state == RequestState.Started) {
 
       context.state = RequestState.Failed;
-      _setProofEnd(requestId, block.timestamp - 1);
+      _setProofEnd(_toEndId(requestId), block.timestamp - 1);
       context.endsAt = block.timestamp - 1;
       emit RequestFailed(requestId);
 
@@ -254,7 +254,7 @@ contract Marketplace is Collateral, Proofs {
     return _timeout();
   }
 
-  function proofEnd(bytes32 slotId) public view returns (uint256) {
+  function proofEnd(SlotId slotId) public view returns (uint256) {
     Slot memory slot = _slot(slotId);
     uint256 end = _end(_toEndId(slot.requestId));
     if (_slotAcceptsProofs(slotId)) {
@@ -337,11 +337,13 @@ contract Marketplace is Collateral, Proofs {
     return ProofId.wrap(SlotId.unwrap(slotId));
   }
 
+  function _toEndId(RequestId requestId) internal pure returns (EndId) {
+    return EndId.wrap(RequestId.unwrap(requestId));
+  }
 
   function _notEqual(RequestId a, uint256 b) internal pure returns (bool) {
     return RequestId.unwrap(a) != bytes32(b);
   }
-
 
   struct Request {
     address client;

--- a/contracts/Proofs.sol
+++ b/contracts/Proofs.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.8;
 
 contract Proofs {
   type ProofId is bytes32;
+  type EndId is bytes32;
 
   uint256 private immutable period;
   uint256 private immutable timeout;
@@ -37,7 +38,7 @@ contract Proofs {
     return timeout;
   }
 
-  function _end(ProofId id) internal view returns (uint256) {
+  function _end(EndId endId) internal view returns (uint256) {
     uint256 end = ends[endId];
     require(end > 0, "Proof ending doesn't exist");
     return ends[endId];
@@ -45,7 +46,7 @@ contract Proofs {
 
   function _endId(ProofId id) internal view returns (EndId) {
     EndId endId = idEnds[id];
-    require(endId > 0, "endId for given id doesn't exist");
+    require(EndId.unwrap(endId) > 0, "endId for given id doesn't exist");
     return endId;
   }
 
@@ -187,7 +188,7 @@ contract Proofs {
   /// @dev Can only be set once
   /// @param endId the endId of the proofs to extend (typically a request id).
   /// @param ending the new end time (in seconds)
-  function _setProofEnd(bytes32 endId, uint256 ending) internal {
+  function _setProofEnd(EndId endId, uint256 ending) internal {
     // TODO: create type aliases for id and endId so that _end() can return
     // EndId storage and we don't need to replicate the below require here
     require (ends[endId] == 0 || ending < block.timestamp, "End exists or must be past");

--- a/contracts/Storage.sol
+++ b/contracts/Storage.sol
@@ -35,58 +35,59 @@ contract Storage is Collateral, Marketplace {
     minCollateralThreshold = _minCollateralThreshold;
   }
 
-  function getRequest(bytes32 requestId) public view returns (Request memory) {
+  function getRequest(RequestId requestId) public view returns (Request memory) {
     return _request(requestId);
   }
 
-  function getSlot(bytes32 slotId) public view returns (Slot memory) {
+  function getSlot(SlotId slotId) public view returns (Slot memory) {
     return _slot(slotId);
   }
 
-  function getHost(bytes32 slotId) public view returns (address) {
+  function getHost(SlotId slotId) public view returns (address) {
     return _host(slotId);
   }
 
-  function missingProofs(bytes32 slotId) public view returns (uint256) {
-    return _missed(slotId);
+  function missingProofs(SlotId slotId) public view returns (uint256) {
+    return _missed(_toProofId(slotId));
   }
 
-  function isProofRequired(bytes32 slotId) public view returns (bool) {
+  function isProofRequired(SlotId slotId) public view returns (bool) {
     if(!_slotAcceptsProofs(slotId)) {
       return false;
     }
-    return _isProofRequired(slotId);
+    return _isProofRequired(_toProofId(slotId));
   }
 
-  function willProofBeRequired(bytes32 slotId) public view returns (bool) {
+  function willProofBeRequired(SlotId slotId) public view returns (bool) {
     if(!_slotAcceptsProofs(slotId)) {
       return false;
     }
-    return _willProofBeRequired(slotId);
+    return _willProofBeRequired(_toProofId(slotId));
   }
 
-  function getChallenge(bytes32 slotId) public view returns (bytes32) {
+  function getChallenge(SlotId slotId) public view returns (bytes32) {
     if(!_slotAcceptsProofs(slotId)) {
       return bytes32(0);
     }
-    return _getChallenge(slotId);
+    return _getChallenge(_toProofId(slotId));
   }
 
-  function getPointer(bytes32 slotId) public view returns (uint8) {
-    return _getPointer(slotId);
+  function getPointer(SlotId slotId) public view returns (uint8) {
+    return _getPointer(_toProofId(slotId));
   }
 
-  function submitProof(bytes32 slotId, bytes calldata proof) public {
-    _submitProof(slotId, proof);
+  function submitProof(SlotId slotId, bytes calldata proof) public {
+    _submitProof(_toProofId(slotId), proof);
   }
 
-  function markProofAsMissing(bytes32 slotId, uint256 period)
+  function markProofAsMissing(SlotId slotId, uint256 period)
     public
     slotMustAcceptProofs(slotId)
   {
-    _markProofAsMissing(slotId, period);
+    ProofId proofId = _toProofId(slotId);
+    _markProofAsMissing(proofId, period);
     address host = _host(slotId);
-    if (_missed(slotId) % slashMisses == 0) {
+    if (_missed(_toProofId(slotId)) % slashMisses == 0) {
         _slash(host, slashPercentage);
 
       if (balanceOf(host) < minCollateralThreshold) {

--- a/contracts/TestAccountLocks.sol
+++ b/contracts/TestAccountLocks.sol
@@ -5,15 +5,15 @@ import "./AccountLocks.sol";
 
 // exposes internal functions for testing
 contract TestAccountLocks is AccountLocks {
-  function createLock(bytes32 id, uint256 expiry) public {
+  function createLock(LockId id, uint256 expiry) public {
     _createLock(id, expiry);
   }
 
-  function lock(address account, bytes32 id) public {
+  function lock(address account, LockId id) public {
     _lock(account, id);
   }
 
-  function unlock(bytes32 id) public {
+  function unlock(LockId id) public {
     _unlock(id);
   }
 
@@ -21,7 +21,7 @@ contract TestAccountLocks is AccountLocks {
     _unlockAccount();
   }
 
-  function extendLockExpiryTo(bytes32 lockId, uint256 expiry) public {
+  function extendLockExpiryTo(LockId lockId, uint256 expiry) public {
     _extendLockExpiryTo(lockId, expiry);
   }
 }

--- a/contracts/TestCollateral.sol
+++ b/contracts/TestCollateral.sol
@@ -12,15 +12,15 @@ contract TestCollateral is Collateral {
     _slash(account, percentage);
   }
 
-  function createLock(bytes32 id, uint256 expiry) public {
+  function createLock(LockId id, uint256 expiry) public {
     _createLock(id, expiry);
   }
 
-  function lock(address account, bytes32 id) public {
+  function lock(address account, LockId id) public {
     _lock(account, id);
   }
 
-  function unlock(bytes32 id) public {
+  function unlock(LockId id) public {
     _unlock(id);
   }
 }

--- a/contracts/TestMarketplace.sol
+++ b/contracts/TestMarketplace.sol
@@ -18,23 +18,23 @@ contract TestMarketplace is Marketplace {
 
   }
 
-  function isCancelled(bytes32 requestId) public view returns (bool) {
+  function isCancelled(RequestId requestId) public view returns (bool) {
     return _isCancelled(requestId);
   }
 
-  function isSlotCancelled(bytes32 slotId) public view returns (bool) {
+  function isSlotCancelled(SlotId slotId) public view returns (bool) {
     return _isSlotCancelled(slotId);
   }
 
-  function freeSlot(bytes32 slotId) public {
+  function freeSlot(SlotId slotId) public {
     _freeSlot(slotId);
   }
 
-  function slot(bytes32 slotId) public view returns (Slot memory) {
+  function slot(SlotId slotId) public view returns (Slot memory) {
     return _slot(slotId);
   }
 
-  function testAcceptsProofs(bytes32 slotId)
+  function testAcceptsProofs(SlotId slotId)
     public
     view
     slotMustAcceptProofs(slotId)

--- a/contracts/TestProofs.sol
+++ b/contracts/TestProofs.sol
@@ -24,7 +24,7 @@ contract TestProofs is Proofs {
     return _timeout();
   }
 
-  function end(ProofId id) public view returns (uint256) {
+  function end(EndId id) public view returns (uint256) {
     return _end(id);
   }
 
@@ -68,7 +68,7 @@ contract TestProofs is Proofs {
     _markProofAsMissing(id, _period);
   }
 
-  function setProofEnd(bytes32 id, uint256 ending) public {
+  function setProofEnd(EndId id, uint256 ending) public {
     _setProofEnd(id, ending);
   }
 }

--- a/contracts/TestProofs.sol
+++ b/contracts/TestProofs.sol
@@ -24,47 +24,47 @@ contract TestProofs is Proofs {
     return _timeout();
   }
 
-  function end(bytes32 id) public view returns (uint256) {
+  function end(ProofId id) public view returns (uint256) {
     return _end(id);
   }
 
-  function missed(bytes32 id) public view returns (uint256) {
+  function missed(ProofId id) public view returns (uint256) {
     return _missed(id);
   }
 
   function expectProofs(
-    bytes32 id,
-    bytes32 endId,
+    ProofId id,
+    EndId endId,
     uint256 _probability
   ) public {
     _expectProofs(id, endId, _probability);
   }
 
-  function unexpectProofs(bytes32 id) public {
+  function unexpectProofs(ProofId id) public {
     _unexpectProofs(id);
   }
 
-  function isProofRequired(bytes32 id) public view returns (bool) {
+  function isProofRequired(ProofId id) public view returns (bool) {
     return _isProofRequired(id);
   }
 
-  function willProofBeRequired(bytes32 id) public view returns (bool) {
+  function willProofBeRequired(ProofId id) public view returns (bool) {
     return _willProofBeRequired(id);
   }
 
-  function getChallenge(bytes32 id) public view returns (bytes32) {
+  function getChallenge(ProofId id) public view returns (bytes32) {
     return _getChallenge(id);
   }
 
-  function getPointer(bytes32 id) public view returns (uint8) {
+  function getPointer(ProofId id) public view returns (uint8) {
     return _getPointer(id);
   }
 
-  function submitProof(bytes32 id, bytes calldata proof) public {
+  function submitProof(ProofId id, bytes calldata proof) public {
     _submitProof(id, proof);
   }
 
-  function markProofAsMissing(bytes32 id, uint256 _period) public {
+  function markProofAsMissing(ProofId id, uint256 _period) public {
     _markProofAsMissing(id, _period);
   }
 

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -4,7 +4,7 @@ require("hardhat-deploy-ethers")
 
 module.exports = {
   solidity: {
-    version: "0.8.4",
+    version: "0.8.8",
     settings: {
       optimizer: {
         enabled: true,


### PR DESCRIPTION
`RequestId`, `SlotId`, `LockId`, `ProofId`, `EndId` types were created to avoid confusion and enforce compiler restrictions.

Closes #21.

### Notes
This is based off of #19, so probably should look at merging that first, then rebase this PR on top of main.