### PR TITLE
List of active requests

### DIFF
--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -267,13 +267,7 @@ contract Marketplace is Collateral, Proofs {
   }
 
   function proofEnd(SlotId slotId) public view returns (uint256) {
-    Slot memory slot = _slot(slotId);
-    uint256 end = _end(_toEndId(slot.requestId));
-    if (_slotAcceptsProofs(slotId)) {
-      return end;
-    } else {
-      return Math.min(end, block.timestamp - 1);
-    }
+    return requestEnd(_slot(slotId).requestId);
   }
 
   function requestEnd(RequestId requestId) public view returns (uint256) {

--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -82,10 +82,7 @@ contract Marketplace is Collateral, Proofs {
     _lock(msg.sender, lockId);
 
     ProofId proofId = _toProofId(slotId);
-    _expectProofs(
-      proofId,
-      _toEndId(requestId),
-      request.ask.proofProbability);
+    _expectProofs(proofId, _toEndId(requestId), request.ask.proofProbability);
     _submitProof(proofId, proof);
 
     slot.host = msg.sender;
@@ -124,9 +121,10 @@ contract Marketplace is Collateral, Proofs {
 
     Request storage request = _request(requestId);
     uint256 slotsLost = request.ask.slots - context.slotsFilled;
-    if (slotsLost > request.ask.maxSlotLoss &&
-        context.state == RequestState.Started) {
-
+    if (
+      slotsLost > request.ask.maxSlotLoss &&
+      context.state == RequestState.Started
+    ) {
       context.state = RequestState.Failed;
       _setProofEnd(_toEndId(requestId), block.timestamp - 1);
       context.endsAt = block.timestamp - 1;
@@ -272,7 +270,7 @@ contract Marketplace is Collateral, Proofs {
 
   function requestEnd(RequestId requestId) public view returns (uint256) {
     uint256 end = _end(_toEndId(requestId));
-    if(_requestAcceptsProofs(requestId)) {
+    if (_requestAcceptsProofs(requestId)) {
       return end;
     } else {
       return Math.min(end, block.timestamp - 1);

--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -370,10 +370,6 @@ contract Marketplace is Collateral, Proofs {
     return RequestId.unwrap(a) != bytes32(b);
   }
 
-  function _toProofId(SlotId slotId) internal pure returns (ProofId) {
-    return ProofId.wrap(SlotId.unwrap(slotId));
-  }
-
   struct Request {
     address client;
     Ask ask;

--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -15,6 +15,7 @@ contract Marketplace is Collateral, Proofs {
   mapping(RequestId => Request) private requests;
   mapping(RequestId => RequestContext) private requestContexts;
   mapping(SlotId => Slot) private slots;
+  mapping(address => RequestId[]) private activeRequests;
 
   constructor(
     IERC20 _token,
@@ -28,6 +29,10 @@ contract Marketplace is Collateral, Proofs {
     marketplaceInvariant
   {
     collateral = _collateral;
+  }
+
+  function myRequests() public view returns (RequestId[] memory) {
+    return activeRequests[msg.sender];
   }
 
   function requestStorage(Request calldata request)

--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -345,6 +345,15 @@ contract Marketplace is Collateral, Proofs {
     return RequestId.unwrap(a) != bytes32(b);
   }
 
+  function _toProofId(SlotId slotId) internal pure returns (ProofId) {
+    return ProofId.wrap(SlotId.unwrap(slotId));
+  }
+
+  function _notEqual(RequestId a, uint256 b) internal pure returns (bool) {
+    return RequestId.unwrap(a) != bytes32(b);
+  }
+
+
   struct Request {
     address client;
     Ask ask;

--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -268,7 +268,7 @@ contract Marketplace is Collateral, Proofs {
 
   function proofEnd(SlotId slotId) public view returns (uint256) {
     Slot memory slot = _slot(slotId);
-    uint256 end = requestEnd(slot.requestId);
+    uint256 end = _end(_toEndId(slot.requestId));
     if (_slotAcceptsProofs(slotId)) {
       return end;
     } else {
@@ -277,7 +277,12 @@ contract Marketplace is Collateral, Proofs {
   }
 
   function requestEnd(RequestId requestId) public view returns (uint256) {
-    return _end(_toEndId(requestId));
+    uint256 end = _end(_toEndId(requestId));
+    if(_requestAcceptsProofs(requestId)) {
+      return end;
+    } else {
+      return Math.min(end, block.timestamp - 1);
+    }
   }
 
   function _price(

--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -97,9 +97,11 @@ contract Marketplace is Collateral, Proofs {
     }
   }
 
-  function _freeSlot(
-    SlotId slotId
-  ) internal slotMustAcceptProofs(slotId) marketplaceInvariant {
+  function _freeSlot(SlotId slotId)
+    internal
+    slotMustAcceptProofs(slotId)
+    marketplaceInvariant
+  {
     Slot storage slot = _slot(slotId);
     RequestId requestId = slot.requestId;
     RequestContext storage context = requestContexts[requestId];
@@ -131,6 +133,7 @@ contract Marketplace is Collateral, Proofs {
       // TODO: send client remaining funds
     }
   }
+
   function payoutSlot(RequestId requestId, uint256 slotIndex)
     public
     marketplaceInvariant
@@ -180,10 +183,8 @@ contract Marketplace is Collateral, Proofs {
     RequestContext storage context = _context(requestId);
     return
       context.state == RequestState.Cancelled ||
-      (
-        context.state == RequestState.New &&
-        block.timestamp > _request(requestId).expiry
-      );
+      (context.state == RequestState.New &&
+        block.timestamp > _request(requestId).expiry);
   }
 
   /// @notice Return true if the request state is RequestState.Finished or if the request duration has elapsed and the request was started.
@@ -194,10 +195,8 @@ contract Marketplace is Collateral, Proofs {
     RequestContext memory context = _context(requestId);
     return
       context.state == RequestState.Finished ||
-      (
-        context.state == RequestState.Started &&
-        block.timestamp > context.endsAt
-      );
+      (context.state == RequestState.Started &&
+        block.timestamp > context.endsAt);
   }
 
   /// @notice Return id of request that slot belongs to
@@ -272,8 +271,8 @@ contract Marketplace is Collateral, Proofs {
   function _price(
     uint64 numSlots,
     uint256 duration,
-    uint256 reward) internal pure returns (uint256) {
-
+    uint256 reward
+  ) internal pure returns (uint256) {
     return numSlots * duration * reward;
   }
 
@@ -311,7 +310,11 @@ contract Marketplace is Collateral, Proofs {
   /// @notice returns true when the request is accepting proof submissions from hosts occupying slots.
   /// @dev Request state must be new or started, and must not be cancelled, finished, or failed.
   /// @param requestId id of the request for which to obtain state info
-  function _requestAcceptsProofs(RequestId requestId) internal view returns (bool) {
+  function _requestAcceptsProofs(RequestId requestId)
+    internal
+    view
+    returns (bool)
+  {
     RequestState s = state(requestId);
     return s == RequestState.New || s == RequestState.Started;
   }
@@ -324,9 +327,7 @@ contract Marketplace is Collateral, Proofs {
     return RequestId.wrap(keccak256(abi.encode(request)));
   }
 
-  function _toSlotId(
-    RequestId requestId,
-    uint256 slotIndex)
+  function _toSlotId(RequestId requestId, uint256 slotIndex)
     internal
     pure
     returns (SlotId)
@@ -353,11 +354,6 @@ contract Marketplace is Collateral, Proofs {
   function _toProofId(SlotId slotId) internal pure returns (ProofId) {
     return ProofId.wrap(SlotId.unwrap(slotId));
   }
-
-  function _notEqual(RequestId a, uint256 b) internal pure returns (bool) {
-    return RequestId.unwrap(a) != bytes32(b);
-  }
-
 
   struct Request {
     address client;
@@ -393,11 +389,11 @@ contract Marketplace is Collateral, Proofs {
   }
 
   enum RequestState {
-    New,        // [default] waiting to fill slots
-    Started,    // all slots filled, accepting regular proofs
-    Cancelled,  // not enough slots filled before expiry
-    Finished,   // successfully completed
-    Failed      // too many nodes have failed to provide proofs, data lost
+    New, // [default] waiting to fill slots
+    Started, // all slots filled, accepting regular proofs
+    Cancelled, // not enough slots filled before expiry
+    Finished, // successfully completed
+    Failed // too many nodes have failed to provide proofs, data lost
   }
 
   struct RequestContext {

--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -268,12 +268,16 @@ contract Marketplace is Collateral, Proofs {
 
   function proofEnd(SlotId slotId) public view returns (uint256) {
     Slot memory slot = _slot(slotId);
-    uint256 end = _end(_toEndId(slot.requestId));
+    uint256 end = requestEnd(slot.requestId);
     if (_slotAcceptsProofs(slotId)) {
       return end;
     } else {
       return Math.min(end, block.timestamp - 1);
     }
+  }
+
+  function requestEnd(RequestId requestId) public view returns (uint256) {
+    return _end(_toEndId(requestId));
   }
 
   function _price(

--- a/test/Marketplace.test.js
+++ b/test/Marketplace.test.js
@@ -9,7 +9,7 @@ const {
   waitUntilStarted,
   waitUntilFinished,
   waitUntilFailed,
-  RequestState
+  RequestState,
 } = require("./marketplace")
 const { price, pricePerSlot } = require("./price")
 const {

--- a/test/Marketplace.test.js
+++ b/test/Marketplace.test.js
@@ -179,7 +179,7 @@ describe("Marketplace", function () {
 
     it("is rejected when request is finished", async function () {
       const lastSlot = await waitUntilStarted(marketplace, request, slot, proof)
-      await waitUntilFinished(marketplace, lastSlot)
+      await waitUntilFinished(marketplace, requestId(request))
       await expect(
         marketplace.fillSlot(slot.request, slot.index, proof)
       ).to.be.revertedWith("Request not accepting proofs")
@@ -262,7 +262,7 @@ describe("Marketplace", function () {
 
     it("checks that proof end time is in the past once finished", async function () {
       const lastSlot = await waitUntilStarted(marketplace, request, slot, proof)
-      await waitUntilFinished(marketplace, lastSlot)
+      await waitUntilFinished(marketplace, requestId(request))
       const now = await currentTime()
       // in the process of calling currentTime and proofEnd,
       // block.timestamp has advanced by 1, so the expected proof end time will
@@ -303,7 +303,7 @@ describe("Marketplace", function () {
 
     it("fails to free slot when finished", async function () {
       const lastSlot = await waitUntilStarted(marketplace, request, slot, proof)
-      await waitUntilFinished(marketplace, lastSlot)
+      await waitUntilFinished(marketplace, requestId(request))
       await expect(marketplace.freeSlot(slotId(slot))).to.be.revertedWith(
         "Slot not accepting proofs"
       )
@@ -340,7 +340,7 @@ describe("Marketplace", function () {
 
     it("pays the host", async function () {
       const lastSlot = await waitUntilStarted(marketplace, request, slot, proof)
-      await waitUntilFinished(marketplace, lastSlot)
+      await waitUntilFinished(marketplace, requestId(request))
       const startBalance = await token.balanceOf(host.address)
       await marketplace.payoutSlot(slot.request, slot.index)
       const endBalance = await token.balanceOf(host.address)
@@ -356,7 +356,7 @@ describe("Marketplace", function () {
 
     it("can only be done once", async function () {
       const lastSlot = await waitUntilStarted(marketplace, request, slot, proof)
-      await waitUntilFinished(marketplace, lastSlot)
+      await waitUntilFinished(marketplace, requestId(request))
       await marketplace.payoutSlot(slot.request, slot.index)
       await expect(
         marketplace.payoutSlot(slot.request, slot.index)
@@ -365,7 +365,7 @@ describe("Marketplace", function () {
 
     it("cannot be filled again", async function () {
       const lastSlot = await waitUntilStarted(marketplace, request, slot, proof)
-      await waitUntilFinished(marketplace, lastSlot)
+      await waitUntilFinished(marketplace, requestId(request))
       await marketplace.payoutSlot(slot.request, slot.index)
       await expect(marketplace.fillSlot(slot.request, slot.index, proof)).to.be
         .reverted
@@ -508,7 +508,7 @@ describe("Marketplace", function () {
 
     it("state is Finished once slot is paid out", async function () {
       const lastSlot = await waitUntilStarted(marketplace, request, slot, proof)
-      await waitUntilFinished(marketplace, lastSlot)
+      await waitUntilFinished(marketplace, requestId(request))
       await marketplace.payoutSlot(slot.request, slot.index)
       await expect(await marketplace.state(slot.request)).to.equal(
         RequestState.Finished
@@ -601,7 +601,7 @@ describe("Marketplace", function () {
           slot,
           proof
         )
-        await waitUntilFinished(marketplace, lastSlot)
+        await waitUntilFinished(marketplace, requestId(request))
         await expect(
           marketplace.testAcceptsProofs(slotId(slot))
         ).to.be.revertedWith("Slot not accepting proofs")
@@ -614,7 +614,7 @@ describe("Marketplace", function () {
           slot,
           proof
         )
-        await waitUntilFinished(marketplace, lastSlot)
+        await waitUntilFinished(marketplace, requestId(request))
         await marketplace.payoutSlot(slot.request, slot.index)
         await expect(
           marketplace.testAcceptsProofs(slotId(slot))
@@ -669,7 +669,7 @@ describe("Marketplace", function () {
       await marketplace.requestStorage(request)
       switchAccount(host)
       const lastSlot = await waitUntilStarted(marketplace, request, slot, proof)
-      await waitUntilFinished(marketplace, lastSlot)
+      await waitUntilFinished(marketplace, requestId(request))
       await marketplace.payoutSlot(slot.request, slot.index)
       switchAccount(client)
       expect(await marketplace.myRequests()).to.deep.equal([])

--- a/test/Marketplace.test.js
+++ b/test/Marketplace.test.js
@@ -84,6 +84,12 @@ describe("Marketplace", function () {
         .withArgs(requestId(request), askToArray(request.ask))
     })
 
+    it("adds request to list of active requests", async function () {
+      await token.approve(marketplace.address, price(request))
+      await marketplace.requestStorage(request)
+      expect(await marketplace.myRequests()).to.deep.equal([requestId(request)])
+    })
+
     it("rejects request with invalid client address", async function () {
       let invalid = { ...request, client: host.address }
       await token.approve(marketplace.address, price(invalid))

--- a/test/Marketplace.test.js
+++ b/test/Marketplace.test.js
@@ -178,7 +178,7 @@ describe("Marketplace", function () {
     })
 
     it("is rejected when request is finished", async function () {
-      const lastSlot = await waitUntilStarted(marketplace, request, slot, proof)
+      await waitUntilStarted(marketplace, request, slot, proof)
       await waitUntilFinished(marketplace, requestId(request))
       await expect(
         marketplace.fillSlot(slot.request, slot.index, proof)
@@ -261,7 +261,7 @@ describe("Marketplace", function () {
     })
 
     it("checks that proof end time is in the past once finished", async function () {
-      const lastSlot = await waitUntilStarted(marketplace, request, slot, proof)
+      await waitUntilStarted(marketplace, request, slot, proof)
       await waitUntilFinished(marketplace, requestId(request))
       const now = await currentTime()
       // in the process of calling currentTime and proofEnd,
@@ -368,7 +368,7 @@ describe("Marketplace", function () {
     })
 
     it("fails to free slot when finished", async function () {
-      const lastSlot = await waitUntilStarted(marketplace, request, slot, proof)
+      await waitUntilStarted(marketplace, request, slot, proof)
       await waitUntilFinished(marketplace, requestId(request))
       await expect(marketplace.freeSlot(slotId(slot))).to.be.revertedWith(
         "Slot not accepting proofs"
@@ -405,7 +405,7 @@ describe("Marketplace", function () {
     })
 
     it("pays the host", async function () {
-      const lastSlot = await waitUntilStarted(marketplace, request, slot, proof)
+      await waitUntilStarted(marketplace, request, slot, proof)
       await waitUntilFinished(marketplace, requestId(request))
       const startBalance = await token.balanceOf(host.address)
       await marketplace.payoutSlot(slot.request, slot.index)
@@ -421,7 +421,7 @@ describe("Marketplace", function () {
     })
 
     it("can only be done once", async function () {
-      const lastSlot = await waitUntilStarted(marketplace, request, slot, proof)
+      await waitUntilStarted(marketplace, request, slot, proof)
       await waitUntilFinished(marketplace, requestId(request))
       await marketplace.payoutSlot(slot.request, slot.index)
       await expect(
@@ -430,7 +430,7 @@ describe("Marketplace", function () {
     })
 
     it("cannot be filled again", async function () {
-      const lastSlot = await waitUntilStarted(marketplace, request, slot, proof)
+      await waitUntilStarted(marketplace, request, slot, proof)
       await waitUntilFinished(marketplace, requestId(request))
       await marketplace.payoutSlot(slot.request, slot.index)
       await expect(marketplace.fillSlot(slot.request, slot.index, proof)).to.be
@@ -573,7 +573,7 @@ describe("Marketplace", function () {
     })
 
     it("state is Finished once slot is paid out", async function () {
-      const lastSlot = await waitUntilStarted(marketplace, request, slot, proof)
+      await waitUntilStarted(marketplace, request, slot, proof)
       await waitUntilFinished(marketplace, requestId(request))
       await marketplace.payoutSlot(slot.request, slot.index)
       await expect(await marketplace.state(slot.request)).to.equal(
@@ -661,12 +661,7 @@ describe("Marketplace", function () {
       })
 
       it("fails when request Finished (isFinished is true)", async function () {
-        const lastSlot = await waitUntilStarted(
-          marketplace,
-          request,
-          slot,
-          proof
-        )
+        await waitUntilStarted(marketplace, request, slot, proof)
         await waitUntilFinished(marketplace, requestId(request))
         await expect(
           marketplace.testAcceptsProofs(slotId(slot))
@@ -674,12 +669,7 @@ describe("Marketplace", function () {
       })
 
       it("fails when request Finished (state set to Finished)", async function () {
-        const lastSlot = await waitUntilStarted(
-          marketplace,
-          request,
-          slot,
-          proof
-        )
+        await waitUntilStarted(marketplace, request, slot, proof)
         await waitUntilFinished(marketplace, requestId(request))
         await marketplace.payoutSlot(slot.request, slot.index)
         await expect(
@@ -734,7 +724,7 @@ describe("Marketplace", function () {
     it("removes request from list when request finishes", async function () {
       await marketplace.requestStorage(request)
       switchAccount(host)
-      const lastSlot = await waitUntilStarted(marketplace, request, slot, proof)
+      await waitUntilStarted(marketplace, request, slot, proof)
       await waitUntilFinished(marketplace, requestId(request))
       await marketplace.payoutSlot(slot.request, slot.index)
       switchAccount(client)

--- a/test/Storage.test.js
+++ b/test/Storage.test.js
@@ -76,7 +76,7 @@ describe("Storage", function () {
   describe("ending the contract", function () {
     it("unlocks the host collateral", async function () {
       await storage.fillSlot(slot.request, slot.index, proof)
-      await waitUntilFinished(storage, slot)
+      await waitUntilFinished(storage, slot.request)
       await expect(storage.withdraw()).not.to.be.reverted
     })
   })

--- a/test/marketplace.js
+++ b/test/marketplace.js
@@ -13,9 +13,8 @@ async function waitUntilStarted(contract, request, slot, proof) {
   return { ...slot, index: lastSlotIdx }
 }
 
-async function waitUntilFinished(contract, lastSlot) {
-  const lastSlotId = slotId(lastSlot)
-  const end = (await contract.proofEnd(lastSlotId)).toNumber()
+async function waitUntilFinished(contract, requestId) {
+  const end = (await contract.requestEnd(requestId)).toNumber()
   await advanceTimeTo(end + 1)
 }
 

--- a/test/marketplace.js
+++ b/test/marketplace.js
@@ -6,11 +6,9 @@ async function waitUntilCancelled(request) {
 }
 
 async function waitUntilStarted(contract, request, slot, proof) {
-  const lastSlotIdx = request.ask.slots - 1
-  for (let i = 0; i <= lastSlotIdx; i++) {
+  for (let i = 0; i < request.ask.slots; i++) {
     await contract.fillSlot(slot.request, i, proof)
   }
-  return { ...slot, index: lastSlotIdx }
 }
 
 async function waitUntilFinished(contract, requestId) {


### PR DESCRIPTION
Maintains a list of active requests per client.
This can be used by the codex node to restore its state when restarted.

Uses an EnumerableSet from OpenZeppelin to ensure that adding and removing from the list is O(1).

Depends on the changes from #20; it needs to be merged first.